### PR TITLE
`ParticleString2D.clear()` was throwing up errors

### DIFF
--- a/lib/toxi/physics2d/ParticleString2D.js
+++ b/lib/toxi/physics2d/ParticleString2D.js
@@ -108,10 +108,10 @@ var	ParticleString2D = function(){
 ParticleString2D.prototype = {
 	clear: function(){
 		for(var i = 0, len = this.links.length; i < len; i++){
-			this.physics.removeSpringElements(s);
+			this.physics.removeSpringElements(this.links[i]);
 		}
-		this.particles.clear();
-		this.links.clear();
+		this.particles = [];
+		this.links = [];
 	},
 	createSpring: function(a,b,len,strength){
 		return new VerletSpring2D(a,b,len,strength);


### PR DESCRIPTION
Hello!

`ParticleString2D.clear()` was throwing an error due to `s` not being defined in the loop. Guess this was an omission. Also `clear` is being called on the two arrays.

Thanks. Awesome conversion you are doing.

_p.s. this commit does not include built files_
