### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-#[Toxiclibsjs](http://haptic-data.com/toxiclibsjs) 
-##an open-source library for computational design tasks with JavaScript. 
+# [Toxiclibsjs](http://haptic-data.com/toxiclibsjs) 
+## an open-source library for computational design tasks with JavaScript. 
 
 [![Spherical Harmonics in three.js](http://s3.amazonaws.com/toxiclibsjs/images/sphericalHarmonicsThree.jpg)](http://haptic-data.com/toxiclibsjs/examples/SphericalHarmonics_threejs.html)
 [![polar_unravel](http://s3.amazonaws.com/toxiclibsjs/images/polarUnravel.gif)](http://haptic-data.com/toxiclibsjs/examples/PolarUnravel_pjs.html)
@@ -9,7 +9,7 @@ Toxiclibs.js is a port of [Karsten Schmidt's Toxiclibs](http://toxiclibs.org) fo
 
 The plethora of examples demonstrate its use for geometry and color manipulation as well as physics, automata and more. The examples pair with such fine libraries as: [Processing.js](http://processingjs.org), [Three.js](http://github.com/mrdoob/three.js), [D3.js](http://github.com/mbostock/d3) or [Raphael.js](http://raphaeljs.com).
 
-##What it is…
+## What it is…
 -	2D/3D geometry
 -	Mesh generation and subdivision
 -	Interpolation / Mapping
@@ -19,7 +19,7 @@ The plethora of examples demonstrate its use for geometry and color manipulation
 
 
 
-#Getting Started with Toxiclibs.js
+# Getting Started with Toxiclibs.js
 
 Toxiclibs.js can be used in the following ways:
 
@@ -27,7 +27,7 @@ Toxiclibs.js can be used in the following ways:
 *	As [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) modules that can be loaded independently or in packages, via [RequireJS](http://requirejs.org)
 *	In [Node.js](http://nodejs.org) or [Browserify](http://browserify.org/) applications, through NPM as commonjs modules.
 
-##Use the build
+## Use the build
 copy the file `build/toxiclibs.js`:
 
 	<script type="text/javascript" src="js/toxiclibs.js"></script>
@@ -35,14 +35,14 @@ copy the file `build/toxiclibs.js`:
 		var myVector = new toxi.geom.Vec2D(window.innerWidth,window.innerHeight).scaleSelf(0.5);
 		var myColor = toxi.color.TColor.newRGB(128/255,64/255,32/255);
 	</script>
-##Use with [RequireJS](http://requirejs.org) or other AMD loader
+## Use with [RequireJS](http://requirejs.org) or other AMD loader
 copy the contents of `lib/`:
 
 	require(['toxi/geom/Vec2D', toxi/color/TColor], function(Vec2D, TColor){
 		var myVector = new Vec2D(window.innerWidth,window.innerHeight).scaleSelf(0.5);
 		var myColor = TColor.newRGB(128/255,64/255,32/255);
 	});
-##Use with [Node.js](http://nodejs.org):
+## Use with [Node.js](http://nodejs.org):
 
 	npm install toxiclibsjs
 then:
@@ -54,7 +54,7 @@ then:
 For comprehensive documentation, read the original libraries [javadocs](http://toxiclibs.org/javadocs/). As the library is still growing, you can compare that documentation to this list of implemented classes.
 
 
-##Toxiclibs.js follows the original package structure
+## Toxiclibs.js follows the original package structure
 The following objects are returned when loading the entire library
 
 
@@ -67,16 +67,16 @@ The following objects are returned when loading the entire library
 * **THREE** - features to ease use with [Three.js](http://github.com/mrdoob/three.js)
 * **utils** - the utils package
 
-##Creating Builds
+## Creating Builds
 Run `make` to generate new versions of the existing builds. There are additional targets defined in the [Makefile](https://github.com/hapticdata/toxiclibsjs/blob/release/Makefile)
-###Custom builds
+### Custom builds
 If you are working with the `build/` files you may wish to create a custom build that only includes the modules you are using in order to save file size. If you are [using the files as AMD modules](#use-with-requirejs-or-other-amd-loader) there is no need for this.
 
 To generate a custom build, space-delimit the modules you want:
 
 	./bin/toxiclibsjs --include "toxi/geom/Vec2D toxi/physics2d" --minify --out "./build/toxiclibsjs-custom.min.js"
 
-##Run the tests
+## Run the tests
 Run `make test` to run the suite of tests.
 
 ## Contributing

--- a/docs/colorutils.md
+++ b/docs/colorutils.md
@@ -1,4 +1,4 @@
-#toxi.color - _colorutils_
+# toxi.color - _colorutils_
 Ported to JavaScript by [Kyle Phillips](http://haptic-data.com) original library by [Karsten Schmidt](http://postspectacular.com). Parts of _colorutils_ were inspired and bits ported from Tom De Smedt & Frederik De Bleser for the "colors" library of [Nodebox.net](http://nodebox.net).
 
 * [TColor](#tcolor) - floating point color datatype in 3 simultaneous spaces: RGB, HSV, CMYK
@@ -13,7 +13,7 @@ Ported to JavaScript by [Kyle Phillips](http://haptic-data.com) original library
 
 read [original javadocs](http://toxiclibs.org/docs/colorutils/) for complete documentation
 
-##TColor
+## TColor
 TColor [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/TColor.js) is the cornerstone of _colorutils_. It represents any 32-bit color in 3 simultaneous spaces with number values between 0 - 1. It provides many convenient methods for conversion to other colors and output into other formats.
 
 
@@ -36,7 +36,7 @@ TColor [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi
 	var c4 = toxi.color.TColor.newCSS( document.body.style.color );
 	
 
-##NamedColor
+## NamedColor
 NamedColor [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/NamedColor.js) is a convenient way to get a TColor based on the name of any [x11 color](http://en.wikipedia.org/wiki/X11_color_names#Color_name_charts).
 
 	//get a TColor by name
@@ -46,7 +46,7 @@ NamedColor [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/
 	//=>[ 'INDIANRED', 'LIGHTCORAL',… ]
 	
 	
-##ColorList
+## ColorList
 ColorList [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/ColorList.js) is a collection of colors. You can simply `#add( tcolor )`, apply adjustments such as `#adjustBrightness( step )` or `#adjustSaturation( step )` to all of them at once, sort them by a [criteria or distance](#access-criteria-and-distance-proxies) and much more.
 
 	var list = new toxi.color.ColorList("my-palette");
@@ -68,7 +68,7 @@ ColorList [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/t
 	var rand = list.getRandom();
 	
 
-##ColorTheme
+## ColorTheme
 ColorTheme [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/ColorTheme.js) is a weighted collection of ColorRange's used to define custom palettes with a certain balance between individual colors/shades. New theme parts can be added via textual descriptors referring to one of the preset ColorRange's and/or NamedColor's, e.g. `"warm springgreen"`. For each theme part a weight has to be specified. The magnitude of the weight value is irrelevant and is only important in relation to the weights of other theme parts.
 
 [view the ColorRange descriptors here](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/ColorRange.js#L316-L326)
@@ -89,7 +89,7 @@ ColorTheme [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/
 	
 
 
-##Strategies - toxi.color.theory.*
+## Strategies - toxi.color.theory.*
 The `toxi.color.theory.*` [package](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/theory/) has several strategies for generating harmonious color palettes from a single color. Instances of these strategies, such as _AnalagousStrategy, ComplementaryStrategy, TriadTheoryStrategy, etc._ all define a function `createListFromColor( sourceTColor )` that returns a `ColorList` of harmonious colors.
 
 	//make a ColorList based off the TriadTheoryStrategy
@@ -106,7 +106,7 @@ The `toxi.color.theory.*` [package](https://github.com/hapticdata/toxiclibsjs/bl
 	// => [ 'complement', 'complementary','splitComplementary','leftSplitComplementary','rightSplitComplementary','analagous','monochrome','triad','tetrad','compound' ]
 
 	
-##ColorRange
+## ColorRange
 
 	var list = new toxi.color.createUsingStrategy("rightSplitComplementary", toxi.color.NamedColor.LIME);
 	range = new toxi.color.ColorRange(list).addBrightnessRange(0,1);
@@ -115,7 +115,7 @@ The `toxi.color.theory.*` [package](https://github.com/hapticdata/toxiclibsjs/bl
 	var customVarianceList = range.getColors( undefined, 100, 0.5);
 	
 
-##Access Criteria and Distance Proxies
+## Access Criteria and Distance Proxies
 AccessCriteria [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/AccessCriteria.js) includes a single instance of each of the different ways to compare colors: _AlphaAccessor, CMYKAccessor, HSVAccessor, LuminanceAccessor, RGBAccessor_
 
 The distance proxies, _CMYKDistanceProxy, HSVDistanceProxy, RGBDistanceProxy_ allow you to sort colors based on their distance to each-other.
@@ -129,7 +129,7 @@ The distance proxies, _CMYKDistanceProxy, HSVDistanceProxy, RGBDistanceProxy_ al
 	list.sortByDistance( new toxi.color.HSVDistanceProxy() );
 
 
-##ColorGradient
+## ColorGradient
 ColorGradient [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/ColorGradient.js) models a multi-color gradient and allows you to receive a `ColorList` of the gradient at any resolution and with custom [interpolators](#).
 
 	var grad = new toxi.color.ColorGradient(),
@@ -146,7 +146,7 @@ ColorGradient [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/l
 	list = grad.calcGradient(10, 20);
 
 
-##ToneMap
+## ToneMap
 
 ToneMap [(source)](https://github.com/hapticdata/toxiclibsjs/blob/master/lib/toxi/color/ToneMap.js) allows you to map a numerical input range to a gradient of colors. In the following example the colors of a flame are mapped to a sine wave:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,8 @@
-#Contributing to Toxiclibsjs
+# Contributing to Toxiclibsjs
 
 Contributions to toxiclibsjs are appreciated, users who would like to contribute are encouraged to [fork the github repository](http://github.com/hapticdata/toxiclibsjs) and send a [pull request](https://github.com/hapticdata/toxiclibsjs/pulls) when they have tested their contribution and are ready for it to be merged into the library. Small fixes may be committed and pulled, or you may [leave an issue](https://github.com/hapticdata/toxiclibsjs/issues) and I will fix it myself.
 
-#Contribution rules
+# Contribution rules
 
 * All code must be written to the [Asynchronous Module Definition](https://github.com/amdjs/amdjs-api/wiki/AMD) specification.
 * The top priority of all code is to follow the functionality and public API of [the original toxiclibs](http://toxiclibs.org). The aim is for there to be no exceptions, if for some reason there is, it must be clearly commented and mentioned in the pull request.

--- a/docs/differences_from_toxiclibs.md
+++ b/docs/differences_from_toxiclibs.md
@@ -1,6 +1,6 @@
-#Differences from the original [Toxiclibs](http://toxiclibs.org)
+# Differences from the original [Toxiclibs](http://toxiclibs.org)
 
-##Arrays / Collections
+## Arrays / Collections
 
 The Java version frequently uses [Collections](http://docs.oracle.com/javase/tutorial/collections/), [Iterators](http://docs.oracle.com/javase/1.4.2/docs/api/java/util/Iterator.html), and [java-specific for-loops](http://stackoverflow.com/questions/8681593/does-javascript-have-an-enhanced-for-loop-syntax-similar-to-javas)[[2]](http://blogs.oracle.com/sundararajan/entry/java_javascript_and_jython). In toxiclibs.js you will see a standard JavaScript usage of arrays. Below is an example of accessing the faces from a TriangleMesh:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,4 +1,4 @@
-#Getting Started with Toxiclibs.js
+# Getting Started with Toxiclibs.js
 
 Toxiclibs.js can be used in the following ways:
 

--- a/docs/processing.md
+++ b/docs/processing.md
@@ -1,4 +1,4 @@
-#Moving from Processing to Processing.js w/ Toxiclibs.js
+# Moving from Processing to Processing.js w/ Toxiclibs.js
 
 If you are targeting both [Processing](http://processing.org) and [Processing.js](http://processingjs.org) there are a couple things to keep in mind.
 

--- a/docs/sugar.md
+++ b/docs/sugar.md
@@ -1,28 +1,28 @@
-#Additional features in Toxiclib.js
+# Additional features in Toxiclib.js
 Toxiclibs.js' top priority is to match the API and functionality of the original library. With that in mind features specific to this javascript version have been added for convenience and to be more idiomatic. Below are some examples.
 
-##No `instanceof` tests
+## No `instanceof` tests
 **Toxiclibs.js never uses `instanceof` tests**, instead it relies on property and method detection, this allows for work between iframes, and work between libraries. For example, the example below works:
 
 	var vec, threeVector3 = new THREE.Vector3( 10, 15, 20 );
 	vec = toxi.geom.Vec3D.randomVector().addSelf( threeVector3 ); // or
 	vec = new toxi.geom.Vec3D( threeVector3 );
 
-##toxi.geom.mesh.OBJWriter#getOutput()
+## toxi.geom.mesh.OBJWriter#getOutput()
 Because file system access is complicated on the web, `getOutput()` has been added to the `OBJWriter` object to get the contents of an .obj file back as a string:
 
 	var obj = new toxi.geom.mesh.OBJWriter();
 	mesh.saveAsOBJ( obj );
 	objContents = obj.getOutput();
 
-##toxi.color.TColor
+## toxi.color.TColor
 Several features have been added to `TColor` to improve interoperability with the browser. Including full integration of CSS colors.
-###TColor.X11
+### TColor.X11
 Color values for [every color name in X11](http://en.wikipedia.org/wiki/Web_colors), as used in CSS:
 	
 	toxi.color.TColor.X11.aquamarine.toRGBAArray() //[ 0.4980392156862745, 1, 0.8313725490196079, 1 ]
 	toxi.color.TColor.X11.indianred.toRGBCSS() // 'rgb(205,92,92)'
-###TColor.newCSS
+### TColor.newCSS
 Accepts any CSS color value, including _hexadecimal, 'rgba()','rgb()','hsl()','hsla()' or any X11 color name_ and creates a TColor object.
 	
 	var color;
@@ -33,35 +33,35 @@ and so on… ultimately this gets you a safe method of using any dom elements cs
 
 	color = toxi.color.TColor.newCSS( $('body').css('background-color') );
 
-###toCSSRGBA(), toCSSRGB(), toCSSHSLA(), toCSSHSL(), toCSSHex()
+### toCSSRGBA(), toCSSRGB(), toCSSHSLA(), toCSSHSL(), toCSSHex()
 convert your color into a string suitable for CSS
 		
 	var color = toxi.color.TColor.newRGB( 0.75, 0.5, 0.25 );
 	color.toRGBACSS() // "rgba(191,127,63,1)"
 	color.toRGBCSS() // "rgb(191,127,63)"
 
-###toInt()
+### toInt()
 convert the `TColor` into an integer, I have found this particularly useful in three.js
 	
 	toxi.color.TColor.newHex("ff00ff").toInt() //16711935
 
 
-##toxi.geom.Vec2D & toxi.geom.Vec3D
+## toxi.geom.Vec2D & toxi.geom.Vec3D
 All functions work with any objects that have `x`,`y` and in Vec3D `z` properties.
 
 	var vec = new toxi.geom.Vec2D({ x: 0.5, y: 0.25 });
 
-##toxi.geom.Rect
+## toxi.geom.Rect
 Constructor function has been overloaded to accept a parameter object:
 
 	var rect = new toxi.geom.Rect({ x: 10, y: 10, width: 100, height: 50 });
 
-##toxi.geom.Spline2D
+## toxi.geom.Spline2D
 Constructor function has been overloaded to accept a parameter object:
 
 	var spline = new toxi.geom.Spline2D({ points: myPointsArray, tightness: 0.1 });
 
-##toxi.math.ScaleMap
+## toxi.math.ScaleMap
 Constructor function has been overloaded to accept a parameter object:
 
 	var map = new toxi.math.ScaleMap({
@@ -69,7 +69,7 @@ Constructor function has been overloaded to accept a parameter object:
 		output: { min: -1, max: 1}
 	});
 
-##toxi.geom.Sphere#toMesh()
+## toxi.geom.Sphere#toMesh()
 `toMesh()` accepts a parameter object:
 
 	sphere.toMesh({
@@ -77,7 +77,7 @@ Constructor function has been overloaded to accept a parameter object:
 		resolution: 20
 	});
 
-##toxi.geom.XAxisAlignedCylinder#toMesh() (as well as Y and Z cylinders)
+## toxi.geom.XAxisAlignedCylinder#toMesh() (as well as Y and Z cylinders)
 `toMesh()` accepts a parameter object:
 
 	cylinder.toMesh({
@@ -86,7 +86,7 @@ Constructor function has been overloaded to accept a parameter object:
 		thetaOffset: Math.PI/6
 	});
 
-##toxi.geom.Cone
+## toxi.geom.Cone
 constructor supports parameter object:
 
 	cone = new toxi.geom.Cone({
@@ -97,7 +97,7 @@ constructor supports parameter object:
 		length: 8
 	});
 
-###toMesh()
+### toMesh()
 `toMesh()` accepts a parameter object:
 
 	cone.toMesh({

--- a/docs/using_requirejs.md
+++ b/docs/using_requirejs.md
@@ -1,4 +1,4 @@
-#Using Toxiclibs.js w/ RequireJS
+# Using Toxiclibs.js w/ RequireJS
 
 With [RequireJS](http://requirejs.org) you can avoid placing any toxiclibsjs objects in the global scope. It allows you to optimize script loading, and you will only load the code that you are using instead of the entire library. To use toxiclibsjs with RequireJS use the files provided in the [lib/](https://github.com/hapticdata/toxiclibsjs/tree/master/lib) directory. Below is an example of how you would use toxiclibsjs within RequireJS:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
